### PR TITLE
Add localAddress Support in Java Http3 ClientBuilder for Network Interface Selection

### DIFF
--- a/src/main/java/net/luminis/http3/Http3Client.java
+++ b/src/main/java/net/luminis/http3/Http3Client.java
@@ -22,6 +22,8 @@ import net.luminis.http3.core.Http3ClientConnection;
 import net.luminis.http3.core.HttpError;
 import net.luminis.http3.core.HttpStream;
 import net.luminis.http3.impl.Http3ConnectionFactory;
+import net.luminis.http3.impl.InterfaceBoundDatagramSocketFactory;
+import net.luminis.quic.DatagramSocketFactory;
 import net.luminis.quic.Statistics;
 import net.luminis.quic.concurrent.DaemonThreadFactory;
 import net.luminis.quic.log.Logger;
@@ -31,6 +33,7 @@ import javax.net.ssl.SSLParameters;
 import java.io.IOException;
 import java.net.Authenticator;
 import java.net.CookieHandler;
+import java.net.InetAddress;
 import java.net.ProxySelector;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -48,17 +51,19 @@ public class Http3Client extends HttpClient {
     private final Duration connectTimeout;
     private final Long receiveBufferSize;
     private final boolean disableCertificateCheck;
+    private final DatagramSocketFactory datagramSocketFactory;
     private final Logger logger;
     private Http3ClientConnection http3Connection;
     protected Http3ConnectionFactory http3ConnectionFactory;
     private final ExecutorService executorService;
 
-    Http3Client(Duration connectTimeout, Long receiveBufferSize, boolean disableCertificateCheck, Logger logger) {
+    Http3Client(Duration connectTimeout, Long receiveBufferSize, boolean disableCertificateCheck, InetAddress inetAddress, Logger logger) {
         this.connectTimeout = connectTimeout;
         this.receiveBufferSize = receiveBufferSize;
         this.disableCertificateCheck = disableCertificateCheck;
         this.logger = logger;
         this.http3ConnectionFactory = new Http3ConnectionFactory(this);
+        this.datagramSocketFactory = new InterfaceBoundDatagramSocketFactory(inetAddress);
 
         executorService = Executors.newCachedThreadPool(new DaemonThreadFactory("http3"));
     }
@@ -122,6 +127,10 @@ public class Http3Client extends HttpClient {
 
     public boolean isDisableCertificateCheck() {
         return disableCertificateCheck;
+    }
+
+    public DatagramSocketFactory getDatagramSocketFactory() {
+        return datagramSocketFactory;
     }
 
     public Logger getLogger() {

--- a/src/main/java/net/luminis/http3/Http3ClientBuilder.java
+++ b/src/main/java/net/luminis/http3/Http3ClientBuilder.java
@@ -24,6 +24,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLParameters;
 import java.net.Authenticator;
 import java.net.CookieHandler;
+import java.net.InetAddress;
 import java.net.ProxySelector;
 import java.net.http.HttpClient;
 import java.time.Duration;
@@ -46,9 +47,16 @@ public class Http3ClientBuilder implements HttpClient.Builder {
     private Long receiveBufferSize;
     private boolean disableCertificateCheck;
     private Logger logger;
+    private InetAddress address;
 
     public Http3ClientBuilder receiveBufferSize(long bufferSize) {
         receiveBufferSize = bufferSize;
+        return this;
+    }
+
+    @Override
+    public HttpClient.Builder localAddress(InetAddress localAddr) {
+        this.address = localAddr;
         return this;
     }
 
@@ -118,6 +126,6 @@ public class Http3ClientBuilder implements HttpClient.Builder {
 
     @Override
     public HttpClient build() {
-        return new Http3Client(connectTimeout, receiveBufferSize, disableCertificateCheck, logger);
+        return new Http3Client(connectTimeout, receiveBufferSize, disableCertificateCheck, address, logger);
     }
 }

--- a/src/main/java/net/luminis/http3/Http3SingleConnectionClient.java
+++ b/src/main/java/net/luminis/http3/Http3SingleConnectionClient.java
@@ -21,6 +21,7 @@ package net.luminis.http3;
 import net.luminis.http3.impl.Http3SingleConnectionFactory;
 import net.luminis.quic.QuicConnection;
 
+import java.net.InetAddress;
 import java.time.Duration;
 
 /**
@@ -28,8 +29,8 @@ import java.time.Duration;
  */
 public class Http3SingleConnectionClient extends Http3Client {
 
-    public Http3SingleConnectionClient(QuicConnection quicConnection, Duration connectTimeout, Long receiveBufferSize) {
-        super(connectTimeout, receiveBufferSize, false, null);
+    public Http3SingleConnectionClient(QuicConnection quicConnection, Duration connectTimeout, Long receiveBufferSize, InetAddress localAddress) {
+        super(connectTimeout, receiveBufferSize, false, localAddress, null);
 
         http3ConnectionFactory = new Http3SingleConnectionFactory(quicConnection);
     }

--- a/src/main/java/net/luminis/http3/impl/Http3ClientConnectionImpl.java
+++ b/src/main/java/net/luminis/http3/impl/Http3ClientConnectionImpl.java
@@ -20,10 +20,7 @@ package net.luminis.http3.impl;
 
 import net.luminis.http3.core.*;
 import net.luminis.qpack.Encoder;
-import net.luminis.quic.QuicClientConnection;
-import net.luminis.quic.QuicConnection;
-import net.luminis.quic.QuicStream;
-import net.luminis.quic.Statistics;
+import net.luminis.quic.*;
 import net.luminis.quic.generic.VariableLengthInteger;
 import net.luminis.quic.log.Logger;
 import net.luminis.quic.log.NullLogger;
@@ -61,11 +58,11 @@ public class Http3ClientConnectionImpl extends Http3ConnectionImpl implements Ht
     private Consumer<HttpStream> bidirectionalStreamHandler;
 
     public Http3ClientConnectionImpl(String host, int port) throws IOException {
-        this(host, port, DEFAULT_CONNECT_TIMEOUT, false, null);
+        this(host, port, DEFAULT_CONNECT_TIMEOUT, false, null, null);
     }
 
-    public Http3ClientConnectionImpl(String host, int port, Duration connectTimeout, boolean disableCertificateCheck, Logger logger) throws IOException {
-        this(createQuicConnection(host, port, connectTimeout, disableCertificateCheck, logger));
+    public Http3ClientConnectionImpl(String host, int port, Duration connectTimeout, boolean disableCertificateCheck, DatagramSocketFactory datagramSocketFactory, Logger logger) throws IOException {
+        this(createQuicConnection(host, port, connectTimeout, disableCertificateCheck, datagramSocketFactory, logger));
     }
 
     public Http3ClientConnectionImpl(QuicConnection quicConnection) {
@@ -113,7 +110,7 @@ public class Http3ClientConnectionImpl extends Http3ConnectionImpl implements Ht
         }
     }
 
-    private static QuicConnection createQuicConnection(String host, int port, Duration connectTimeout, boolean disableCertificateCheck, Logger logger) throws SocketException, UnknownHostException {
+    private static QuicConnection createQuicConnection(String host, int port, Duration connectTimeout, boolean disableCertificateCheck, DatagramSocketFactory datagramSocketFactory, Logger logger) throws SocketException, UnknownHostException {
         QuicClientConnection.Builder builder = QuicClientConnection.newBuilder();
         try {
             builder.uri(new URI("//" + host + ":" + port));
@@ -136,6 +133,7 @@ public class Http3ClientConnectionImpl extends Http3ConnectionImpl implements Ht
         if (disableCertificateCheck) {
             builder.noServerCertificateCheck();
         }
+        builder.socketFactory(datagramSocketFactory);
         builder.logger(logger != null? logger: new NullLogger());
         return builder.build();
     }

--- a/src/main/java/net/luminis/http3/impl/Http3ConnectionFactory.java
+++ b/src/main/java/net/luminis/http3/impl/Http3ConnectionFactory.java
@@ -100,7 +100,7 @@ public class Http3ConnectionFactory {
         Http3ClientConnection http3Connection;
         try {
             Duration connectTimeout = http3Client.connectTimeout().orElse(DEFAULT_CONNECT_TIMEOUT);
-            http3Connection = new Http3ClientConnectionImpl(address.host, address.port, connectTimeout, http3Client.isDisableCertificateCheck(), http3Client.getLogger());
+            http3Connection = new Http3ClientConnectionImpl(address.host, address.port, connectTimeout, http3Client.isDisableCertificateCheck(), http3Client.getDatagramSocketFactory(), http3Client.getLogger());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/net/luminis/http3/impl/InterfaceBoundDatagramSocketFactory.java
+++ b/src/main/java/net/luminis/http3/impl/InterfaceBoundDatagramSocketFactory.java
@@ -1,0 +1,24 @@
+package net.luminis.http3.impl;
+
+import net.luminis.quic.DatagramSocketFactory;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+
+public class InterfaceBoundDatagramSocketFactory implements DatagramSocketFactory {
+    private final InetAddress address;
+    public InterfaceBoundDatagramSocketFactory(InetAddress address) {
+        this.address = address;
+    }
+    private DatagramSocket bindToLocalAddress(InetAddress address) throws SocketException {
+        return new DatagramSocket(new InetSocketAddress(address, 0));
+    }
+    @Override
+    public DatagramSocket createSocket(InetAddress inetAddress) throws SocketException {
+        DatagramSocket datagramSocket = bindToLocalAddress(address);
+        datagramSocket.connect(new InetSocketAddress(inetAddress, 443));
+        return datagramSocket;
+    }
+}

--- a/src/main/java/net/luminis/http3/impl/InterfaceBoundDatagramSocketFactory.java
+++ b/src/main/java/net/luminis/http3/impl/InterfaceBoundDatagramSocketFactory.java
@@ -17,8 +17,6 @@ public class InterfaceBoundDatagramSocketFactory implements DatagramSocketFactor
     }
     @Override
     public DatagramSocket createSocket(InetAddress inetAddress) throws SocketException {
-        DatagramSocket datagramSocket = bindToLocalAddress(localAddress);
-        datagramSocket.connect(new InetSocketAddress(inetAddress, 443));
-        return datagramSocket;
+        return bindToLocalAddress(localAddress);
     }
 }

--- a/src/main/java/net/luminis/http3/impl/InterfaceBoundDatagramSocketFactory.java
+++ b/src/main/java/net/luminis/http3/impl/InterfaceBoundDatagramSocketFactory.java
@@ -8,16 +8,16 @@ import java.net.InetSocketAddress;
 import java.net.SocketException;
 
 public class InterfaceBoundDatagramSocketFactory implements DatagramSocketFactory {
-    private final InetAddress address;
-    public InterfaceBoundDatagramSocketFactory(InetAddress address) {
-        this.address = address;
+    private final InetAddress localAddress;
+    public InterfaceBoundDatagramSocketFactory(InetAddress localAddress) {
+        this.localAddress = localAddress;
     }
     private DatagramSocket bindToLocalAddress(InetAddress address) throws SocketException {
         return new DatagramSocket(new InetSocketAddress(address, 0));
     }
     @Override
     public DatagramSocket createSocket(InetAddress inetAddress) throws SocketException {
-        DatagramSocket datagramSocket = bindToLocalAddress(address);
+        DatagramSocket datagramSocket = bindToLocalAddress(localAddress);
         datagramSocket.connect(new InetSocketAddress(inetAddress, 443));
         return datagramSocket;
     }

--- a/src/test/java/net/luminis/http3/impl/InterfaceBoundDatagramSocketFactoryTest.java
+++ b/src/test/java/net/luminis/http3/impl/InterfaceBoundDatagramSocketFactoryTest.java
@@ -1,0 +1,22 @@
+package net.luminis.http3.impl;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.BindException;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class InterfaceBoundDatagramSocketFactoryTest {
+    @Test
+    public void shouldThrowExceptionWhenInvalidLocalAddressIsProvided() {
+        assertThatThrownBy(() -> {
+            InetAddress localAddress = InetAddress.getByName("123.123.123.123");
+            InterfaceBoundDatagramSocketFactory socketFactory = new InterfaceBoundDatagramSocketFactory(localAddress);
+            InetAddress address = InetAddress.getByName("111.111.111.111");
+            DatagramSocket socket = socketFactory.createSocket(address);
+            socket.close();
+        }).isInstanceOf(BindException.class);
+    }
+}


### PR DESCRIPTION
This pull request support for specifying a local network interface in the Http3 ClientBuilder. The localAddress feature enables developers to configure which network interface should be used for outgoing communications.

localAddress Implementation : Added support for the localAddress property in the ClientBuilder. Users can now set the network interface to control the source of their network traffic.

The creator interface of the HTTP3SingleConnectionClient has been modified. You must choose whether to modify this part or disable the network interface selection function and use an existing creator.

Additional Notes:
I'm a novice developer. Feedback and suggestions are welcome. Let me know if additional adjustments are needed!
I am not good at English. I am using translator and GPT. Please understand if my English is strange.