### PR TITLE
fix: support JPMS with module-info (#14)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,6 @@ jar {
     from {
         configurations.compileClasspath.findAll { it.name =~ /qpack.*\.jar/ }.collect { it.isDirectory() ? it : zipTree(it) }
     }
-    exclude 'module-info.class'
 }
 
 task uberJar(type: Jar) {
@@ -66,7 +65,7 @@ task uberJar(type: Jar) {
     archiveBaseName = "flupke-uber"
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
-    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.txt', 'module-info.class'
+    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.txt'
     with jar
 }
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module tech.kwik.flupke {
+	requires java.net.http;
+	
+	requires tech.kwik.core;
+	requires tech.kwik.qpack;
+}


### PR DESCRIPTION
### (do not merge)
only made the basic changes - this _does not_ build

it seems that flupke creates an uber-jar and shades `qpack` into the JAR.
(and the uber-jar is what is published to Maven Central).

i would also prefer that to be changed, and if `qpack` should be `transitive` that be done too

but @ptrd you may have some reason for this?
