### PR TITLE
Update Flupke dependency version to 0.9

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Latest release can be found at maven central:
     <dependency>
         <groupId>tech.kwik</groupId>
         <artifactId>flupke</artifactId>
-        <version>0.9.0</version>
+        <version>0.9</version>
     </dependency> 
 
 Flupke uses the HTTP Client API introduced with Java 11, e.g. 


### PR DESCRIPTION
Version published to Maven Central is `0.9`, not `0.9.0`.
Signed-off-by: Mahied Maruf <contact@mechite.com>