### PR TITLE
Added support for more versions of webtransport

### DIFF
--- a/core/src/main/java/tech/kwik/flupke/impl/Http3ClientConnectionImpl.java
+++ b/core/src/main/java/tech/kwik/flupke/impl/Http3ClientConnectionImpl.java
@@ -197,6 +197,7 @@ public class Http3ClientConnectionImpl extends Http3ConnectionImpl implements Ht
 
         builder.socketFactory(datagramSocketFactory);
         builder.logger(logger != null? logger: new NullLogger());
+        builder.enableDatagramExtension();
         return builder.build();
     }
 

--- a/core/src/main/java/tech/kwik/flupke/impl/Http3ClientConnectionImpl.java
+++ b/core/src/main/java/tech/kwik/flupke/impl/Http3ClientConnectionImpl.java
@@ -434,7 +434,13 @@ public class Http3ClientConnectionImpl extends Http3ConnectionImpl implements Ht
         QuicStream httpStream = quicConnection.createStream(true);
         httpStream.getOutputStream().write(headersFrame.toBytes(qpackEncoder));
 
-        Http3Frame responseFrame = readFrame(httpStream.getInputStream());
+        // RFC 9114 §7.2.8: unknown frame types on a request stream MUST be ignored.
+        // Loop past any unknown/GREASE frames until we get the actual response.
+        Http3Frame responseFrame;
+        do {
+            responseFrame = readFrame(httpStream.getInputStream());
+        } while (responseFrame instanceof UnknownFrame);
+
         if (responseFrame instanceof HeadersFrame) {
             HttpResponseInfo responseInfo;
             try {

--- a/core/src/main/java/tech/kwik/flupke/impl/Http3ConnectionImpl.java
+++ b/core/src/main/java/tech/kwik/flupke/impl/Http3ConnectionImpl.java
@@ -312,7 +312,7 @@ public class Http3ConnectionImpl implements Http3Connection {
             OutputStream clientControlOutput = clientControlStream.getOutputStream();
             clientControlOutput.write(STREAM_TYPE_CONTROL_STREAM);
 
-            SettingsFrame settingsFrame = new SettingsFrame();
+            SettingsFrame settingsFrame = new SettingsFrame(0, 0, true);
             settingsFrame.addParameters(settingsParameters);
             ByteBuffer serializedSettings = settingsFrame.getBytes();
             clientControlStream.getOutputStream().write(serializedSettings.array(), 0, serializedSettings.limit());

--- a/core/src/main/java/tech/kwik/flupke/webtransport/impl/AbstractSessionFactoryImpl.java
+++ b/core/src/main/java/tech/kwik/flupke/webtransport/impl/AbstractSessionFactoryImpl.java
@@ -34,12 +34,17 @@ import static tech.kwik.flupke.webtransport.Constants.WEBTRANSPORT_SESSION_GONE;
 
 public abstract class AbstractSessionFactoryImpl implements SessionFactory {
 
-    // https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-13.html#section-9.2
-    // "The SETTINGS_WT_MAX_SESSIONS setting indicates that the specified HTTP/3 endpoint is WebTransport-capable and
-    //  the number of concurrent sessions it is willing to receive."
-    // "Setting Name: WT_MAX_SESSIONS
-    //  Value: 0x14e9cd29"
-    public static final long SETTINGS_WT_MAX_SESSIONS = 0x14e9cd29L;
+    // WebTransport setting IDs — multiple variants for cross-draft compatibility.
+    // draft-ietf-webtrans-http3-13: 0x14e9cd29
+    public static final long SETTINGS_WT_MAX_SESSIONS_DRAFT13 = 0x14e9cd29L;
+    // draft-06+ (current): 0xc671706a
+    public static final long SETTINGS_WT_MAX_SESSIONS = 0xc671706aL;
+    // Deprecated (removed in draft-06): used by older servers
+    public static final long SETTINGS_WT_ENABLE_DEPRECATED = 0x2b603742L;
+    public static final long SETTINGS_WT_MAX_SESSIONS_DEPRECATED = 0x2b603743L;
+    // H3 datagram settings
+    public static final long SETTINGS_ENABLE_DATAGRAM = 0x33L;
+    public static final long SETTINGS_ENABLE_DATAGRAM_DEPRECATED = 0xFFD277L;
 
     protected final Map<Long, SessionImpl> sessionRegistry = new ConcurrentHashMap<>();
     private final ReentrantLock registrationLock = new ReentrantLock();

--- a/core/src/main/java/tech/kwik/flupke/webtransport/impl/ClientSessionFactoryImpl.java
+++ b/core/src/main/java/tech/kwik/flupke/webtransport/impl/ClientSessionFactoryImpl.java
@@ -63,16 +63,25 @@ public class ClientSessionFactoryImpl extends AbstractSessionFactoryImpl impleme
             HttpRequest request = HttpRequest.newBuilder(new URI("https://" + server + ":" + serverPort)).build();
             httpClientConnection = httpClient.createConnection(request);
 
-            // https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-13.html#section-3.1
-            // "A client supporting WebTransport over HTTP/3 MUST send the SETTINGS_WT_MAX_SESSIONS setting with a value greater than "0"."
+            // Send all WebTransport setting variants for maximum cross-implementation compatibility.
+            // Current (draft-06+)
             httpClientConnection.addSettingsParameter(SETTINGS_WT_MAX_SESSIONS, 1);
+            // Draft-13 (used by moqtail.dev / older Flupke servers)
+            httpClientConnection.addSettingsParameter(SETTINGS_WT_MAX_SESSIONS_DRAFT13, 1);
+            // Deprecated variants (used by some servers)
+            httpClientConnection.addSettingsParameter(SETTINGS_WT_ENABLE_DEPRECATED, 1);
+            httpClientConnection.addSettingsParameter(SETTINGS_WT_MAX_SESSIONS_DEPRECATED, 1);
+            // H3 datagram support (RFC 9297) — current and deprecated (Chrome still sends deprecated)
+            httpClientConnection.addSettingsParameter(SETTINGS_ENABLE_DATAGRAM, 1);
+            httpClientConnection.addSettingsParameter(SETTINGS_ENABLE_DATAGRAM_DEPRECATED, 1);
             httpClientConnection.connect();
 
-            // https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-13.html#section-5.2
-            // "This document defines a SETTINGS_WT_MAX_SESSIONS setting that allows the server to limit the maximum number
-            //  of concurrent WebTransport sessions on a single HTTP/3 connection.
-            //  The client MUST NOT open more simultaneous sessions than indicated in the server SETTINGS parameter. "
-            maxSessions = httpClientConnection.getPeerSettingsParameter(SETTINGS_WT_MAX_SESSIONS).orElse(0L);
+            // Check all WT_MAX_SESSIONS variants the server might advertise.
+            // Default to unlimited (Long.MAX_VALUE) since many servers omit this setting.
+            maxSessions = httpClientConnection.getPeerSettingsParameter(SETTINGS_WT_MAX_SESSIONS)
+                .or(() -> httpClientConnection.getPeerSettingsParameter(SETTINGS_WT_MAX_SESSIONS_DRAFT13))
+                .or(() -> httpClientConnection.getPeerSettingsParameter(SETTINGS_WT_MAX_SESSIONS_DEPRECATED))
+                .orElse(Long.MAX_VALUE);
 
             httpClientConnection.registerUnidirectionalStreamType(STREAM_TYPE_WEBTRANSPORT, this::handleUnidirectionalStream);
             httpClientConnection.registerBidirectionalStreamHandler(this::handleBidirectionalStream);

--- a/core/src/main/java/tech/kwik/flupke/webtransport/impl/WebTransportExtensionFactory.java
+++ b/core/src/main/java/tech/kwik/flupke/webtransport/impl/WebTransportExtensionFactory.java
@@ -33,11 +33,6 @@ import java.util.function.Consumer;
 
 public class WebTransportExtensionFactory implements Http3ServerExtensionFactory {
 
-    // https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-13.html#section-9.2
-    // "Setting Name: WT_MAX_SESSIONS
-    //  Value: 0x14e9cd29
-    public static final long WT_MAX_SESSIONS = 0x14e9cd29L;
-
     private final Map<String, Consumer<Session>> webTransportHandlers = new HashMap<>();
     private ExecutorService executor = Executors.newCachedThreadPool(new DaemonThreadFactory("webtransport"));
 
@@ -48,10 +43,15 @@ public class WebTransportExtensionFactory implements Http3ServerExtensionFactory
 
     @Override
     public Map<Long, Long> getExtensionSettings() {
-        // https://www.ietf.org/archive/id/draft-ietf-webtrans-http3-13.html#section-3.1
-        // "A server supporting WebTransport over HTTP/3 MUST send both the SETTINGS_WT_MAX_SESSIONS setting with
-        //  a value greater than "0" ..."
-        return Map.of(WT_MAX_SESSIONS, 1L);
+        // Advertise all WebTransport setting variants for cross-implementation compatibility.
+        Map<Long, Long> settings = new HashMap<>();
+        settings.put(AbstractSessionFactoryImpl.SETTINGS_WT_MAX_SESSIONS, 1L);
+        settings.put(AbstractSessionFactoryImpl.SETTINGS_WT_MAX_SESSIONS_DRAFT13, 1L);
+        settings.put(AbstractSessionFactoryImpl.SETTINGS_WT_ENABLE_DEPRECATED, 1L);
+        settings.put(AbstractSessionFactoryImpl.SETTINGS_WT_MAX_SESSIONS_DEPRECATED, 1L);
+        settings.put(AbstractSessionFactoryImpl.SETTINGS_ENABLE_DATAGRAM, 1L);
+        settings.put(AbstractSessionFactoryImpl.SETTINGS_ENABLE_DATAGRAM_DEPRECATED, 1L);
+        return settings;
     }
 
     /**


### PR DESCRIPTION
I'm using flupke/kwik to build a POC or MoQ streaming with Wowza Streaming engine.  Kwik worked out of the box, but I was having some trouble connecting to any relay I wanted to with the current Webtransport implementation.  After capturing working and non working sessions, it revealed that there are a lot of implementations using a bunch of different versions of the spec.  I added code to attempt to work with a larger variety of those and am now able to connect to most of the mow-relays in developement.